### PR TITLE
LINK-921 - Release new one_more_time gem version 0.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,28 @@
 PATH
   remote: .
   specs:
-    one_more_time (0.1.0)
+    one_more_time (0.1.1)
       activerecord (>= 6.0.2.1, < 6.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3)
-      activesupport (= 6.1.3)
-    activerecord (6.1.3)
-      activemodel (= 6.1.3)
-      activesupport (= 6.1.3)
-    activesupport (6.1.3)
+    activemodel (6.1.6)
+      activesupport (= 6.1.6)
+    activerecord (6.1.6)
+      activemodel (= 6.1.6)
+      activesupport (= 6.1.6)
+    activesupport (6.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4)
-    i18n (1.8.9)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.14.4)
+    minitest (5.16.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -40,7 +40,7 @@ GEM
     timecop (0.9.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
@@ -52,4 +52,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   2.0.2
+   2.2.32

--- a/lib/one_more_time/version.rb
+++ b/lib/one_more_time/version.rb
@@ -1,3 +1,3 @@
 module OneMoreTime
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Release Version 0.1.1

### ¿What is the next?
**Publish the new release to RubyGem**
We need to publish it to RubyGem.

First, we need to build a .gem file:
`gem build one_more_time`

Once created, the file can be finally published.

Execute:
`gem push one_more_time-0.1.1.gem`

Confirm that a new release was published.

### Test
`bundle exec rspec spec` and to check that this is working with `shipping_label_service` execute the next instructions:

1. Download this branch on your local machine.
2. Open `shipping_label_service` and change the `Gemfile` to `gem "one_more_time", path: "../one_more_time" `
3. Execute `bundle exec gruf `on `shipping_label_service`
4. Open `freshly` (monolith) in your local machine and execute `rails c`
5. Copy the next code: [https://wiki.freshly.com/wiki/Test_Shipping_Labels](https://wiki.freshly.com/wiki/Test_Shipping_Labels) and execute it in the console of freshly.

If everything continues working with this change you should see a message like this:
```
=> <FreshlyServices::ShippingLabelService::PurchaseLabelResponse: shipping_label: <FreshlyServices::ShippingLabelService::ShippingLabel: label_format: :ZPL, label_data: "^XA^POI
^XA
^LH0,0
^CI28
^FT20,50^A0N,24,24^FDFreshly^FS
^FT20,80^A0N,24,24^FDHerp McDerp^FS
^FT20,110^A0N,24,24^FD8704 BOLLMAN PL^FS
^FT20,140^A0N,24,24^FDSAVAGE, MD 20763-9747^FS
^FT20,170^A0N,24,24^FD^FS
^FO500,40,2
^BXN,6,200
^FD1LS7278091634871-1|1|M7278|FRSHSVGE|RD|20763|CLVD|CLVD|3432|0|2022-06-22T01:00|-240|US|44115-3311|R|2405 E 38TH ST|Herp McDerp|Herp McDerp||3.94|7.87|3.94|in|11|lbs|7^FS
^FT20,240^A0N,39,38^FDShip To^FS
^FT50,310^A0N,34,34^FDHerp McDerp^FS
^FT50,350^A0N,34,34^FD2405 E 38TH ST^FS
^FT50,390^A0N,34,34^FDCLEVELAND, OH 44115-3311^FS
^FT50,430^A0N,34,33^FD^FS
^FT50,470^A0N,34,34^FD^FS
^FO22,490^GFA,01152,01152,00012,:Z64:
eJzt0jsOwyAMBmBHDO7G2JFjdMzR4Dwd2itwFI6QoRIZUKlxDKKPSG2VpVL/hU8WMgahsyQA6I2MUbJhz8/7hyE7WsUJmtVMNuKpcxBj9Ow91z168vhkd2c6Cuxi7VSd4bUxAjpV5wfj4CR7issozci+wkhW1X7FQYwXONC9FPdPYFPdQ27vM6/6SDmLS7Azz4bTUuf+xTswuZq
epLNlh0cPP/B/vvc/7+cG55nWfw==:5576
^FO122,490^GB90,70,70^FS
^FT120,545^A0N,56,56^FR^FD RD ^FS
^FT280,545^A0N,56,56^FB500,1,0,R^FD3432^FS
^FO20,570^GB760,8,8^FS
^BY3,3,160^FT50,762^BCN,,Y,N
^FD1LS7278091634871-1^FS
^FO20,820^GB760,8,8^FS
^FT20,894^A0N,56,56^FDCLVD^FS

^FT20,936^A0N,28,28^FDReady By: 06/19/2022 at 3:00 pm^FS
^FT20,968^A0N,32,32^FDDelivery By: 06/21/2022 at 9:00 pm^FS
^FT380,936^A0N,24,24^FB400,1,0,R^FDL3.94xW7.87xH3.94 in    ^FS
^FT380,960^A0N,24,24^FB400,1,0,R^FD11.00 lbs    ^FS
^FT20,1000^A0N,24,24^FDRef1: 1234-yay^FS
^FT20,1025^A0N,24,24^FD^FS
^FT20,1050^A0N,24,24^FDPiece Ref: prcl_adea6eb8f6044612967ab9f7eb0290a5^FS
^FT20,1195^A0N,20,20^FB700,7,0,L^FD^FS
^PQ1,0,1,Y^XZ
", tracking_code: "1LS7278091634871-1", tracking_url: "http://www.lasership.com/track/1LS7278091634871-1", token: "gid://shipping-label-service/ShippingLabel/136", shipment_reference: "fade6646-9113-4edc-a5d
3-211d5028dd76", provider_code: "easypost", provider_label_id: "shp_4c041f10d7774e8183cb5f168199ec8f">, shipment_reference: "">
```